### PR TITLE
Fix trust relationship assume role policy

### DIFF
--- a/cloudformation/jupiterone-cloudformation.json
+++ b/cloudformation/jupiterone-cloudformation.json
@@ -46,7 +46,7 @@
                 "AWS": {
                   "Fn::Join": [
                     "",
-                    ["arn:aws:iam::", { "Ref": "J1AwsAccountId" }, ":role/JupiterOneIntegrationAws*"]
+                    ["arn:aws:iam::", { "Ref": "J1AwsAccountId" }, ":root"]
                   ]
                 }
               },


### PR DESCRIPTION
Receiving an error applying this: `Invalid principal in policy: "AWS":"arn:aws:iam::564077667165:role/JupiterOneIntegrationAws*"`. A wildcard is not allowed (see [discussion about "unique principal ID"](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_policy-examples.html#example-delegate-xaccount-rolesapi)).

These changes say, the target account role trusts the JupiterOne account to control which users/roles in the JupiterOne account can assume the target account role.

Specifying a specific JupiterOne account role is undesirable from the point of view of maintaining flexibility in how JupiterOne infrastructure is managed. The target account will need to trust that the JupiterOne account is properly managing which of its roles can assume the target account role.

Note that the "Manual creation via AWS Management Console" process would lead to this same configuration.