### PR TITLE
Add jupiterone security audit policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,64 @@ From your AWS Management Console, perform the following steps:
 
 1.  Leave **Require MFA** unchecked and click **Next: Permissions**.
 
-1.  In the Policy search box, search for and select `SecurityAudit` policy. This
-    is an AWS-managed IAM policy that grants access to read security
-    configurations of the AWS resources.
+1.  Click **Create Policy**, select the **JSON** tab, and enter the following document content:
+```json
+{
+  "Version":"2012-10-17", 
+  "Statement" : [{
+    "Effect" : "Allow",           
+    "Resource" : "*",
+    "Action" : [
+      "athena:BatchGet*",
+      "athena:Get*",
+      "athena:List*",
+      "batch:Describe*",
+      "batch:List*",
+      "dynamodb:Describe*",
+      "dynamodb:List*",
+      "ecs:List*",
+      "eks:DescribeCluster",
+      "eks:ListClusters",
+      "elasticache:Describe*",
+      "elasticache:List*",
+      "elasticmapreduce:Describe*",
+      "elasticmapreduce:List*",
+      "es:Describe*",
+      "es:List*",
+      "glue:Get*",
+      "inspector:Describe*",
+      "inspector:Get*",
+      "inspector:List*",
+      "kinesis:Describe*",
+      "kinesis:List*",
+      "waf:List*",               
+      "waf:Get*"
+    ]
+  },
+  {
+      "Effect": "Allow",
+      "Action": [
+        "apigateway:GET"
+      ],
+      "Resource": [
+        "arn:aws:apigateway:*::/*"
+      ]
+  }]
+}
+```
 
-1.  With the `SecurityAudit` policy selected, click **Next: Review**.
+1.  Click **Review Policy** and verify the permissions.
+
+1.  Enter `JupiterOneSecurityAudit` as the **Name** and click **Create Policy**.
+
+1.  Return to the **Create Role** tab in your browser. Click the Policy table's
+    **Refresh Icon**.
+
+1.  In the Policy search box, search for `SecurityAudit`. Select both `SecurityAudit`
+    and `JupiterOneSecurityAudit` policies. `SecurityAudit` is an AWS-managed IAM
+    policy.
+
+1.  With both policies selected, click **Next: Review**.
 
 1.  Enter `JupiterOne` as the **Role Name**, and optionally, enter a description
     for the Role.

--- a/cloudformation/jupiterone-cloudformation.json
+++ b/cloudformation/jupiterone-cloudformation.json
@@ -66,9 +66,6 @@
               "inspector:List*",
               "kinesis:Describe*",
               "kinesis:List*",
-              "macie:Get*",
-              "macie:List*",
-              "macie:Describe*",
               "waf:List*",               
               "waf:Get*"
             ]

--- a/cloudformation/jupiterone-cloudformation.json
+++ b/cloudformation/jupiterone-cloudformation.json
@@ -33,10 +33,65 @@
     }
   },
   "Resources": {
+    "JupiterOneSecurityAuditPolicy": {
+      "Type" : "AWS::IAM::ManagedPolicy",
+      "Properties" : {
+        "Description" : "JupiterOne SecurityAudit policy",
+        "Path" : "/",
+        "PolicyDocument" : {
+          "Version":"2012-10-17", 
+          "Statement" : [{
+            "Effect" : "Allow",           
+            "Resource" : "*",
+            "Action" : [
+              "athena:BatchGet*",
+              "athena:Get*",
+              "athena:List*",
+              "batch:Describe*",
+              "batch:List*",
+              "dynamodb:Describe*",
+              "dynamodb:List*",
+              "ecs:List*",
+              "eks:DescribeCluster",
+              "eks:ListClusters",
+              "elasticache:Describe*",
+              "elasticache:List*",
+              "elasticmapreduce:Describe*",
+              "elasticmapreduce:List*",
+              "es:Describe*",
+              "es:List*",
+              "glue:Get*",
+              "inspector:Describe*",
+              "inspector:Get*",
+              "inspector:List*",
+              "kinesis:Describe*",
+              "kinesis:List*",
+              "macie:Get*",
+              "macie:List*",
+              "macie:Describe*",
+              "waf:List*",               
+              "waf:Get*"
+            ]
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                "apigateway:GET"
+              ],
+              "Resource": [
+                "arn:aws:apigateway:*::/*"
+              ]
+          }]
+        }
+      }
+    },
     "JupiterOneRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
-        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/SecurityAudit"],
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/SecurityAudit",
+          "!Ref JupiterOneSecurityAuditPolicy"
+        ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [


### PR DESCRIPTION
This adds read/list actions that go beyond the AWS managed SecurityAudit policy to support JupiterOne. Although JupiterOne does not yet invoke all these actions, the goal is to avoid asking customers to update the policy every time the JupiterOne AWS integration ingests additional resources.

<img width="1005" alt="screen shot 2018-08-10 at 11 06 49 am" src="https://user-images.githubusercontent.com/2571/43966329-99d1509c-9c8f-11e8-97b6-fa355c4bbf8c.png">

`macie` had to be dropped at this time because it is reported an an unrecognized service.