### PR TITLE
Fix CLI command to ack naming capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ JupiterOne AWS integration:
 ## Using AWS CLI
 
 ```bash
-aws cloudformation create-stack --stack-name JupiterOneIntegration --capabilities CAPABILITY_IAM --template-url https://s3.amazonaws.com/jupiterone-prod-us-jupiter-aws-integration/jupiterone-cloudformation.json
+aws cloudformation create-stack --stack-name JupiterOneIntegration --capabilities CAPABILITY_NAMED_IAM --template-url https://s3.amazonaws.com/jupiterone-prod-us-jupiter-aws-integration/jupiterone-cloudformation.json
 ```
 
 ## Manual creation via AWS Management Console


### PR DESCRIPTION
When naming things, such as introduced by 6016a43716576fd8af77b362563ece4abfc7621d, one must acknowledge there be 🐉